### PR TITLE
OP-5083 - Fix error code return for an invalid coupon.

### DIFF
--- a/content/v3/resellers/coupons.md
+++ b/content/v3/resellers/coupons.md
@@ -46,7 +46,7 @@ If there is an error in processing the request, an error message will be returne
 
 Error returned when a coupon is not found.
 
-<%= headers 422 %>
+<%= headers 404 %>
 <%= json(OfferEngine.reseller_coupon_not_found()) %>
 
 Error returned when cancel coupon fails.

--- a/lib/resources/coupon.rb
+++ b/lib/resources/coupon.rb
@@ -50,9 +50,9 @@ module OfferEngine
 
   def self.reseller_coupon_not_found
     {
-      :status            => "error",
-      :error_type        => "invalid_coupon",
-      :error_msg         => "coupon could not be found",
+        status:  "error",
+        message: "Failed. not found.",
+        type:    "find_failed"
     }
   end
 
@@ -84,5 +84,4 @@ module OfferEngine
       :error_msg         => "Failed. not found.",
     }
   end
-
 end


### PR DESCRIPTION
If the coupon cannot be found, a 404 is thrown.

Updating the documentation to reflect that.

![screen shot 2014-03-25 at 10 59 05 am](https://f.cloud.github.com/assets/358891/2515820/3df7952c-b447-11e3-83fb-2702f3a71e17.png)
