### PR TITLE
OP-5103 - add Zip Code to credit card documentation.

### DIFF
--- a/content/v1/full_purchase.md
+++ b/content/v1/full_purchase.md
@@ -76,6 +76,9 @@ month
 
 year
 : _String_ Four-digit year for the payment card expiration date when a payment card number is provided
+
+zip_code
+: _String_ The zip code for the billing address for the payment card when a payment card number is provided.
 <br/><br/>
 
 ### Shipping address parameters

--- a/content/v1/users/credit_cards.md
+++ b/content/v1/users/credit_cards.md
@@ -47,6 +47,9 @@ month
 year
 : _Integer_ Expiration year in digit format.
 
+zip_code
+: _String_ The zip code for the billing address for the card.
+
 ### Response
 
 <%= headers 200 %>

--- a/lib/resources/credit_card.rb
+++ b/lib/resources/credit_card.rb
@@ -1,21 +1,22 @@
 module OfferEngine
   def self.credit_card
     {
-      :id=>"2342f8073e",
-      :credit_card_id=>"2342f8073e",
-      :number=>"XXXX0027",
-      :type=>"visa",
-      :primary=>true,
-      :deleted=>false
+      :id => "2342f8073e",
+      :credit_card_id => "2342f8073e",
+      :number => "XXXX0027",
+      :type => "visa",
+      :primary => true,
+      :deleted => false
     }
   end
 
   def self.credit_card_request
     {
       :number => "424242424242424", 
-      :cvv => 123, 
+      :verification_value => 123,
       :month => 1, 
       :year => 2014,
+      :zip_code => "90210"
     }
   end
 end


### PR DESCRIPTION
Add the zip code to the documentation for credit cards.

I did some searches, and I think I found every place that this is required.
