### PR TITLE
OP-5482 - V3 API - Include 'redemption_url' in Get Deals API

### DIFF
--- a/lib/resources/deal.rb
+++ b/lib/resources/deal.rb
@@ -11,7 +11,7 @@ module OfferEngine
         title: "$50 for $100 worth of Dining",
         type: "daily-deal",
         images: {
-          tiny_url: "https://d2x9dz1etb1m98.cloudfront.net/ugassets/deal/images/b/5/ff54ac03/tiny.jpg", 
+          tiny_url: "https://d2x9dz1etb1m98.cloudfront.net/ugassets/deal/images/b/5/ff54ac03/tiny.jpg",
           small_url: "https://d2x9dz1etb1m98.cloudfront.net/ugassets/deal/images/b/5/ff54ac03/tiny.jpg",
           medium_url: "https://d2x9dz1etb1m98.cloudfront.net/ugassets/deal/images/b/5/ff54ac03/medium.jpg",
           large_url: "https://d2x9dz1etb1m98.cloudfront.net/ugassets/deal/images/b/5/ff54ac03/large.jpg"
@@ -327,6 +327,9 @@ percent_fee
 
 purchase_url
 : _String_ The URL for deal purchase web page
+
+redemption_url
+: _String_ The URL a purchaser will redeem the coupon/redemption code
 
 region_id
 : _String_ Unique identifier for region in which the deal is for sale


### PR DESCRIPTION
Per [OP-5463](http://jira.mygazoo.com/browse/OP-5463), Redemption URL is made available in V3 Get Deals API.

I came up with the text describing Redemption URL based on tool tip available in Deal Creation/Edit page.
![reference](https://cloud.githubusercontent.com/assets/3762885/3274605/af76f5de-f331-11e3-8a2d-ad76a0226cc6.png)
